### PR TITLE
Add error hinting for type mismatches

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
         "import"
     ],
     "rules": {
-      "quotes": 0,
+      "quotes": [1, "double"],
       "no-nested-ternary": 0,
       "no-confusing-arrow": 0,
       "padded-blocks": 0,

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.15.0",
-    "eslint-config-airbnb-base": "^11.1.0",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-import": "^2.6.1",
     "mocha": "^3.0.2"
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-/* global before, it, describe */
+/* global it, describe */
 
 const chai = require("chai");
 const varium = require(".");

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -87,11 +87,11 @@ STRING_DEFAULT : String | def
   });
 
   it("should hadle EOF", () => {
-    reader({}, { STRING: "" }, `STRING:String`);
-    reader({}, {}, `STRING:String|`);
-    reader({}, {}, `STRING:String|asd`);
-    reader({}, {}, `STRING:String|asd#`);
-    reader({}, {}, `STRING:String|asd#asd`);
+    reader({}, { STRING: "" }, "STRING:String");
+    reader({}, {}, "STRING:String|");
+    reader({}, {}, "STRING:String|asd");
+    reader({}, {}, "STRING:String|asd#");
+    reader({}, {}, "STRING:String|asd#asd");
   });
 
   it("should handle complex default values", () => {

--- a/src/interpret/parse.js
+++ b/src/interpret/parse.js
@@ -28,7 +28,7 @@ module.exports = R.pipe(
       const stack = duplicated.map(definition =>
         `  Env var ${definition.name} is declared more than once.`
       ).join("\n");
-      const err = new Error(`Varium: Error reading manifest`);
+      const err = new Error("Varium: Error reading manifest");
       err.stack = stack;
       throw err;
     } else {

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -124,7 +124,7 @@ const suggestValidatorName = (validators, typeName) => {
     }))
     .filter(validator => validator.distance < 3);
 
-  return R.sortBy(R.prop('distance'), possibleMatches)
+  return R.sortBy(R.prop("distance"), possibleMatches)
     .map(validator => validator.type);
 };
 
@@ -137,11 +137,11 @@ module.exports = (customValidators, manifest, env) => {
 
       let errorMessage = "";
 
-      if (suggestions.length === 0) errorMessage = `Unable to offer any suggestions.`;
+      if (suggestions.length === 0) errorMessage = "Unable to offer any suggestions.";
       else if (suggestions.length === 1 || suggestions[0].distance === 0) {
         errorMessage = `Maybe you meant ${suggestions[0]}?`;
       }
-      else { errorMessage = `Maybe you meant one of these: ${suggestions.join('|')}`; }
+      else { errorMessage = `Maybe you meant one of these: ${suggestions.join("|")}`; }
 
       return {
         error$: `The type ${definition.type} for env var "${definition.name}" does not exist.\n${errorMessage}`,

--- a/src/validate/index.js
+++ b/src/validate/index.js
@@ -1,9 +1,49 @@
+const R = require("ramda");
 const debug = require("debug");
 
 const logName = debug("varium:validate:name");
 const logValue = debug("varium:validate:value");
 
 const isnt = x => x === "" || x === undefined;
+
+const levDistance = (a, b) => {
+  if (typeof a === "undefined") return 9000;
+  if (typeof b === "undefined") return 9000;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  if (a.toLowerCase() === b.toLowerCase()) return 0;
+
+  const matrix = [];
+
+  // increment along the first column of each row
+  let i;
+  for (i = 0; i <= b.length; i += 1) {
+    matrix[i] = [i];
+  }
+
+  // increment each column in the first row
+  let j;
+  for (j = 0; j <= a.length; j += 1) {
+    matrix[0][j] = j;
+  }
+
+  // Fill in the rest of the matrix
+  for (i = 1; i <= b.length; i += 1) {
+    for (j = 1; j <= a.length; j += 1) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(matrix[i - 1][j - 1] + 1, // substitution
+                         Math.min(matrix[i][j - 1] + 1, // insertion
+                         matrix[i - 1][j] + 1)); // deletion
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+};
+
 
 const Validators = {
   String: (value, def) => value || def,
@@ -75,13 +115,36 @@ const Validators = {
   },
 };
 
+
+const suggestValidatorName = (validators, typeName) => {
+  const possibleMatches = Object.keys(validators)
+    .map(validatorType => ({
+      type: validatorType,
+      distance: levDistance(validatorType, typeName)
+    }))
+    .filter(validator => validator.distance < 3);
+
+  return R.sortBy(R.prop('distance'), possibleMatches)
+    .map(validator => validator.type);
+};
+
 module.exports = (customValidators, manifest, env) => {
   const validators = Object.assign({}, Validators, customValidators);
 
   return manifest.map((definition) => {
     if (!validators[definition.type]) {
+      const suggestions = suggestValidatorName(validators, definition.type);
+
+      let errorMessage = "";
+
+      if (suggestions.length === 0) errorMessage = `Unable to offer any suggestions.`;
+      else if (suggestions.length === 1 || suggestions[0].distance === 0) {
+        errorMessage = `Maybe you meant ${suggestions[0]}?`;
+      }
+      else { errorMessage = `Maybe you meant one of these: ${suggestions.join('|')}`; }
+
       return {
-        error$: `The type ${definition.type} for env var "${definition.name}" does not exist.`,
+        error$: `The type ${definition.type} for env var "${definition.name}" does not exist.\n${errorMessage}`,
       };
     }
     if (env[definition.name] === undefined && definition.default === undefined) {

--- a/src/validate/index.test.js
+++ b/src/validate/index.test.js
@@ -1,4 +1,4 @@
-/* global before, it, describe */
+/* global it, describe */
 
 const validator = require(".");
 const chai = require("chai");
@@ -17,7 +17,18 @@ describe("Validate", () => {
 
     it("should return error if type doesn't exist", () => {
       validator(null, [{ name: "TEST", type: "Test" }], {})
-        .should.deep.equal([{ error$: "The type Test for env var \"TEST\" does not exist." }]);
+        .should.deep.equal([{ error$: "The type Test for env var \"TEST\" does not exist.\nUnable to offer any suggestions." }]);
+    });
+
+    it("should return suggestions if type is close to a known type", () => {
+      validator(null, [{ name: "TEST", type: "int" }], {})
+        .should.deep.equal([{ error$: "The type int for env var \"TEST\" does not exist.\nMaybe you meant Int?" }]);
+
+      validator(null, [{ name: "TEST", type: "bint" }], {})
+        .should.deep.equal([{ error$: "The type bint for env var \"TEST\" does not exist.\nMaybe you meant Int?" }]);
+
+      validator(null, [{ name: "TEST", type: "sloat" }], {})
+        .should.deep.equal([{ error$: "The type sloat for env var \"TEST\" does not exist.\nMaybe you meant Float?" }]);
     });
 
     it("should return as many results as definitions", () => {
@@ -34,7 +45,7 @@ describe("Validate", () => {
 
     it("should return error if type doesn't exist", () => {
       validator(null, [{ name: "TEST", type: "Test" }], {})
-        .should.deep.equal([{ error$: "The type Test for env var \"TEST\" does not exist." }]);
+        .should.deep.equal([{ error$: "The type Test for env var \"TEST\" does not exist.\nUnable to offer any suggestions." }]);
     });
 
     it("should return as many results as definitions", () => {


### PR DESCRIPTION
# What

- Remove unused globals in test files since eslint was sad about it
- Add a levenshtine-distance function for figuring out distances between two type names
- When a type is not found as a validator, report the closest validators to it by a max of 3 levenshtine-distance changes (3 inserts, deletes or mods)
- If the there is a type with the same letters but different case (e.g `String` and `string`), only suggest that type name as the fix


# Why

This was the errors can aid you if you make a typo in the type name, or forget the correct case (e.g `JSON` or `json` or `Json`?)