### PR TITLE
Specify dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ramda": "^0.26.1"
   },
   "peerDependencies": {
-    "debug": "2.x"
+    "debug": "^2.6.9"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Newer version of npm requires specific dependencies versions, https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh